### PR TITLE
fix: checkout context detection, dedup, and missing subscription

### DIFF
--- a/src/BentoEvents/Model/EventDeduplicator.php
+++ b/src/BentoEvents/Model/EventDeduplicator.php
@@ -26,18 +26,17 @@ class EventDeduplicator
         $tableName = $this->resourceConnection->getTableName(self::TABLE_NAME);
 
         try {
-            $affectedRows = $connection->insertOnDuplicate(
-                $tableName,
-                [
-                    'quote_id' => $quoteId,
-                    'event_name' => $eventName,
-                    'sent_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
-                ],
-                [] // empty update columns = INSERT IGNORE behavior
+            $sentAt = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+            $connection->query(
+                sprintf(
+                    'INSERT IGNORE INTO %s (quote_id, event_name, sent_at) VALUES (?, ?, ?)',
+                    $tableName
+                ),
+                [$quoteId, $eventName, $sentAt]
             );
 
-            // 1 = inserted (first time), 0 = duplicate (already sent)
-            return $affectedRows > 0;
+            // INSERT IGNORE: 1 = inserted (first time), 0 = ignored (duplicate)
+            return (int)$connection->fetchOne('SELECT ROW_COUNT()') === 1;
         } catch (\Exception $e) {
             $this->logger->warning('Event dedup insert failed', [
                 'quote_id' => $quoteId,

--- a/src/BentoEvents/Observer/Quote/QuoteSaved.php
+++ b/src/BentoEvents/Observer/Quote/QuoteSaved.php
@@ -143,15 +143,14 @@ class QuoteSaved implements ObserverInterface
     {
         try {
             $moduleName = $this->request->getModuleName();
-            if ($moduleName === 'checkout') {
+            if ($moduleName === 'checkout' || $moduleName === 'onestepcheckout') {
                 return true;
             }
 
-            if ($moduleName === 'rest' || $moduleName === 'webapi_rest') {
-                $uri = (string)$this->request->getRequestUri();
-                if (str_contains($uri, '/carts/') || str_contains($uri, '/guest-carts/')) {
-                    return true;
-                }
+            // REST API context: module name may be 'rest', 'webapi_rest', or null
+            $uri = (string)$this->request->getRequestUri();
+            if (str_contains($uri, '/carts/') || str_contains($uri, '/guest-carts/')) {
+                return true;
             }
 
             return false;

--- a/src/BentoEvents/Setup/Patch/Data/CreateBentoSubscriptions.php
+++ b/src/BentoEvents/Setup/Patch/Data/CreateBentoSubscriptions.php
@@ -38,6 +38,7 @@ class CreateBentoSubscriptions implements DataPatchInterface
         'bento.newsletter.subscribed',
         'bento.newsletter.unsubscribed',
         'bento.cart.abandoned',
+        'bento.checkout.started',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- **isCheckoutContext()**: `getModuleName()` returns `null` for REST API calls — removed module name guard, check URI directly. Added `onestepcheckout` match.
- **EventDeduplicator**: `insertOnDuplicate([])` updates all columns on duplicate (Magento quirk) — replaced with `INSERT IGNORE` + `ROW_COUNT()`.
- **CreateBentoSubscriptions**: Added missing `bento.checkout.started` to the data patch event list.

## Files Changed
| File | Change |
|------|--------|
| `Observer/Quote/QuoteSaved.php` | Fix `isCheckoutContext()` — URI check no longer gated behind module name |
| `Model/EventDeduplicator.php` | Replace `insertOnDuplicate()` with `INSERT IGNORE` |
| `Setup/Patch/Data/CreateBentoSubscriptions.php` | Add `bento.checkout.started` to event list |

## Test Plan
- [x] Detected via U1-T-001 and U1-T-003 (Bento data pipeline validation)
- [ ] After merge + `composer update` + `setup:upgrade`: re-run U1-T-001 and U1-T-003
- [ ] Verify `$checkoutStarted` appears in Bento dashboard on checkout
- [ ] Verify dedup blocks duplicate events (only 1 "queued" log entry per quote)

Fixes #1, Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)